### PR TITLE
fix: formaTime function date type logic error   修复formaTime 函数参数逻辑判断的问题

### DIFF
--- a/components/timePicker/timePicker.js
+++ b/components/timePicker/timePicker.js
@@ -541,7 +541,7 @@ Component({
 
 function formatTime(date) {
   
-  if (typeof date == 'string' || 'number') {
+  if (typeof date === 'string' || typeof date === 'number') {
     try {
       date = date.replace(/-/g, '/')//兼容ios
     } catch (error) {


### PR DESCRIPTION
Signed-off-by: EthanShen <ethanshenwork@gmail.com>

## Pre-Checklist

- [x] I have read through the readme document

- [x] My code has the necessary comments and tests

## Description 
this PR is to fix the timePicker.js file line 542 formatTime function parameter date judge logic error. 
when date’s data type isn’t string, such as array or object type. 
the sentence of ‘if’ judge sentence,   date = new Date(date) is still executed, which may cause fatal error.

这个PR是为了解决timePicker.js文件中 formatTime函数 参数 date 逻辑判断错误的问题 当函数参数date的类型不是string或者number类型而是array 或者 object类型 if语句中 date = new Date(date) 的逻辑仍旧会执行 这将导致一些致命的后果

## Related Issue

Close #18 